### PR TITLE
Upgrade Rails to 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '3.2.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 6.0'
+gem 'rails', '~> 6.1.7'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,7 +317,7 @@ DEPENDENCIES
   patreon!
   pg (>= 0.18, < 2.0)
   puma (~> 6.4)
-  rails (~> 6.0)
+  rails (~> 6.1.7)
   rollbar
   selenium-webdriver
   simplecov
@@ -329,7 +329,7 @@ DEPENDENCIES
   webdrivers
 
 RUBY VERSION
-   ruby 3.2.2p53
+  ruby 3.2.2p53
 
 BUNDLED WITH
   4.0.10

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ Bundler.require(*Rails.groups)
 module StretchlyServer
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 6.1
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Bundler had already resolved `rails 6.1.7.10`, but the Gemfile pin was still `~> 6.0` and `config.load_defaults` was `6.0`. This PR makes the 6.1 baseline official so the next hop (6.1 → 7.0) starts from a clean state.

- Tighten Gemfile pin to `~> 6.1.7`
- Flip `config.load_defaults` from `6.0` to `6.1`